### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/model/data.rkt
+++ b/model/data.rkt
@@ -126,7 +126,7 @@
   (for-syntax
     mischief)
   refined-acl2/proof/term
-  unstable/list)
+  (only-in racket/list check-duplicates))
 
 (struct ast [source] #:transparent)
 
@@ -275,7 +275,7 @@
 (define (environment-union . es)
   (define decls (append-map environment-decls es))
   (cond
-    [(check-duplicate (map decl-name decls)) =>
+    [(check-duplicates (map decl-name decls)) =>
      (lambda {v}
        (error 'environment-union
          "duplicate declaration for ~a"

--- a/model/parse.rkt
+++ b/model/parse.rkt
@@ -9,7 +9,7 @@
   refined-acl2/model/data
   refined-acl2/model/subst
   refined-acl2/model/names
-  unstable/list
+  (only-in racket/list check-duplicates)
   (for-template
     racket/base
     refined-acl2/expansion/runtime))
@@ -511,7 +511,7 @@
     #:literal-sets {kernel-literals}
     [(#%plain-lambda {} :instance-body)
      #:fail-when
-     (check-duplicate (@ label) #:key syntax-e)
+     (check-duplicates (@ label) #:key syntax-e)
      "duplicate label"
      #:fail-when
      (check-duplicate-identifier (@ name))


### PR DESCRIPTION
Most of the functionality of that package will be moved into the core libraries by Racket PR #972, and `unstable-list-lib` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-list-lib` package, as it will not be part of the main distribution in future versions.
